### PR TITLE
Don't run pre-commit hooks on jupyter notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,7 @@ repos:
   rev: v0.11.12
   hooks:
     - id: ruff
+      types_or: [ python, pyi ]
       args: [ --fix ]
     - id: ruff-format
+      types_or: [ python, pyi ]


### PR DESCRIPTION
I edited the pre-commit config as instructed [here](https://github.com/astral-sh/ruff-pre-commit) to avoid running the pre-commit on jupyter notebooks. Reasoning that notebooks are for one-off checks and tests that don't need to adhere to standards.