### PR TITLE
Fix dataset dimension usage

### DIFF
--- a/pm25ml/collectors/ned/data_reader_merra.py
+++ b/pm25ml/collectors/ned/data_reader_merra.py
@@ -84,7 +84,7 @@ class MerraDataReader(NedDataReader):
         dataset: xarray.Dataset,
     ) -> None:
         # Check if all expected dimensions are present
-        actual_dimensions = list(dataset.dims.keys())
+        actual_dimensions = list(dataset.sizes.keys())
         missing_expected_dimensions = [
             dim for dim in self.expected_dimensions if dim not in actual_dimensions
         ]


### PR DESCRIPTION
## Summary
- use `dataset.sizes` instead of deprecated `dataset.dims` in MERRA-2 reader

## Testing
- `poetry run ruff check .`
- `poetry run mypy pm25ml`
- `poetry run pytest -m "not integration"`

------
https://chatgpt.com/codex/tasks/task_b_685a6a82733083258c52698171c024f6